### PR TITLE
Fix model config file loading from HuggingFace hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Joint Distillation and Quantization](https://arxiv.org/pdf/2203.11239.pdf)."
 ## Sample Command
 - The following command will train an `8-8-8 3-1` model on CNN/DailyMail dataset. You may use [accelerate](https://github.com/huggingface/accelerate) for distributed training. 
     ```bash
-    python3 run_summarization_no_trainer.py 
-      --model_name_or_path bart-base-cnn 
-      --dataset_name cnn_dailymail 
-      --dataset_config_name 3.0.0 
-      --pred_distill 
-      --intermediate_distill 
-      --num_train_epochs 20 
-      --weight_bits 8 
-      --do_train 
-      --do_test 
-      --distill_encoder 3 
-      --distill_decoder 1 
-      --learning_rate 3e-5
+    python3 run_summarization_no_trainer.py \
+      --model_name_or_path ainize/bart-base-cnn \
+      --dataset_name cnn_dailymail \
+      --dataset_config_name 3.0.0 \
+      --pred_distill \
+      --intermediate_distill \
+      --num_train_epochs 20 \
+      --weight_bits 8 \
+      --do_train \
+      --do_test \
+      --distill_encoder 3 \
+      --distill_decoder 1 \
+      --learning_rate 3e-5 
     ```
 ## Citation
 You may cite our work using

--- a/quant/configuration_bart_quant.py
+++ b/quant/configuration_bart_quant.py
@@ -23,6 +23,9 @@ from transformers.configuration_utils import PretrainedConfig
 from transformers.onnx import OnnxConfigWithPast
 from transformers.utils import logging
 
+from huggingface_hub import hf_hub_url, cached_download
+
+
 import json
 import sys
 import os
@@ -215,11 +218,11 @@ class BartConfig(PretrainedConfig):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        config_file = os.path.join(pretrained_model_name_or_path, CONFIG_NAME)
+        config_file = cached_download(hf_hub_url(pretrained_model_name_or_path, CONFIG_NAME))
         logger.info("loading configuration file {}".format(config_file))
         # Load config
-        config = cls.from_json_file(config_file)
-
+        config = cls.from_json_file(config_file)  
+        
         # Update config with kwargs if needed
         to_remove = []
         for key, value in kwargs.items():

--- a/quant/configuration_bart_quant.py
+++ b/quant/configuration_bart_quant.py
@@ -25,7 +25,6 @@ from transformers.utils import logging
 
 from huggingface_hub import hf_hub_url, cached_download
 
-
 import json
 import sys
 import os


### PR DESCRIPTION
*Issue:*
Code fails at model training stage, because 
```
@classmethod
    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
        config_file = os.path.join(pretrained_model_name_or_path, CONFIG_NAME)
```
assumes that configuration file should be saved in `model_name_or_path` folder. But when you load a model from the Hugging Face hub, the model will be saved in the cache by default, not in the project directory.
```
 @classmethod
    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
        config_file = cached_download(hf_hub_url(pretrained_model_name_or_path, CONFIG_NAME))
```

*Description of changes:*

* Replace `os.path.join` by `cached_download` that support both cases: loading from pre-saved folder and from the hub.
* Update model path in README file. Hub path `bart-base-cnn` doesn't exist, replaced by `ainize/bart-base-cnn`
* Add `\` for `run_summarization_no_trainer.py` parameters to make code example from README executable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
